### PR TITLE
Add optional parameter for naming static node

### DIFF
--- a/gazebo_ros/include/gazebo_ros/node.hpp
+++ b/gazebo_ros/include/gazebo_ros/node.hpp
@@ -49,13 +49,13 @@ public:
   /// Destructor
   virtual ~Node();
 
-  /// Get a static node called "gazebo" which can be shared by several plugins.
+  /// Get a static node which can be shared by several plugins.
   /**
    * \details This will call rclcpp::init if it hasn't been called yet.
    * \details The node is created the first time this is called.
    * \return A shared pointer to a #gazebo_ros::Node
    */
-  static SharedPtr Get();
+  static SharedPtr Get(std::string node_name = "gazebo");
 
   /// Get reference to a #gazebo_ros::Node and add it to the global #gazebo_ros::Executor.
   /**

--- a/gazebo_ros/src/node.cpp
+++ b/gazebo_ros/src/node.cpp
@@ -144,14 +144,14 @@ Node::SharedPtr Node::Get(sdf::ElementPtr sdf, std::string node_name)
   return node;
 }
 
-Node::SharedPtr Node::Get()
+Node::SharedPtr Node::Get(std::string node_name /*="gazebo"*/)
 {
   Node::SharedPtr node = static_node_.lock();
 
   if (!node) {
     rclcpp::NodeOptions node_options;
     node_options.allow_undeclared_parameters(true);
-    node = CreateWithArgs("gazebo", "", node_options);
+    node = CreateWithArgs(node_name, "", node_options);
     static_node_ = node;
   }
 


### PR DESCRIPTION
Add optional parameter for naming static node. This can be useful in VisualPlugins to avoid naming problems, because Gazebo creates separate render scenes for each clients and the server.